### PR TITLE
Python 2.6 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - 2.6
   - 2.7
   - 3.3
 script: python test_gfm.py

--- a/gfm.py
+++ b/gfm.py
@@ -32,9 +32,9 @@ def gfm(text):
         string = "\n\n" + extractions[matchobj.group(1)]
         return string
 
-    text = re.sub("<pre>.*?<\/pre>", extract_pre_block, text, flags=re.S)
+    text = re.sub("(?s)<pre>.*?<\/pre>", extract_pre_block, text)
     text = re.sub("(^(?! {4}|\t)\w+_\w+_\w[\w_]*)", escape_underscore, text)
-    text = re.sub("^[\w\<][^\n]*\n+", newlines_to_brs, text, flags=re.M)
+    text = re.sub("(?m)^[\w\<][^\n]*\n+", newlines_to_brs, text)
     text = re.sub("\{gfm-extraction-([0-9a-f]{32})\}", insert_pre_block, text)
 
     return text


### PR DESCRIPTION
Python 2.6 Regex doesn't have the `flags` argument, so I replaced the use of `flags=` with inline flags.
